### PR TITLE
do not intercept the ORDER_PAY event if the order is being paid with …

### DIFF
--- a/EventListeners/StripePaymentEventListener.php
+++ b/EventListeners/StripePaymentEventListener.php
@@ -21,6 +21,7 @@ use Thelia\Model\ConfigQuery;
 use Thelia\Model\Order as OrderModel;
 use Thelia\Model\OrderStatusQuery;
 use Thelia\Tools\URL;
+use Thelia\Model\ModuleQuery;
 
 /**
  * Class StripePaymentEventListener
@@ -104,6 +105,14 @@ class StripePaymentEventListener implements EventSubscriberInterface
     }
 
     /**
+     * returns the StripePayment module code
+     */
+    public function getStripeCode()
+    {
+        return "StripePayment";
+    }    
+
+    /**
      * Send data to Stripe, save token, change order status & get response
      * @param OrderEvent $event
      * @throws \Exception
@@ -111,6 +120,11 @@ class StripePaymentEventListener implements EventSubscriberInterface
      */
     public function stripePayment(OrderEvent $event)
     {
+        $stripeModule = ModuleQuery::create()->findOneByCode($this->getStripeCode());
+        if ($event->getOrder()->getPaymentModuleId() !== $stripeModule->getId()) {
+            return;
+        }
+        
         $logMessage = null;
         $userMessage = null;
 

--- a/EventListeners/StripePaymentEventListener.php
+++ b/EventListeners/StripePaymentEventListener.php
@@ -120,15 +120,14 @@ class StripePaymentEventListener implements EventSubscriberInterface
      */
     public function stripePayment(OrderEvent $event)
     {
+        $order = $event->getPlacedOrder();
         $stripeModule = ModuleQuery::create()->findOneByCode($this->getStripeCode());
-        if ($event->getOrder()->getPaymentModuleId() !== $stripeModule->getId()) {
+        if ($order->getPaymentModuleId() !== $stripeModule->getId()) {
             return;
         }
         
         $logMessage = null;
         $userMessage = null;
-
-        $order = $event->getPlacedOrder();
 
         \Stripe\Stripe::setApiKey(StripePayment::getConfigValue('secret_key'));
 


### PR DESCRIPTION
StripePayment makes conflict with other payment module, like Paypal.
It keeps catching the ORDER_PAY event, even if the order is to be paid with another payment module.
Here is a fix for that problem.