### PR TITLE
Mettez à jour votre intégration pour vous préparer à la SCA

### DIFF
--- a/Config/config-form.yml
+++ b/Config/config-form.yml
@@ -3,6 +3,10 @@ config:
     type: checkbox
     label: Activated ?
     help: Do you want to activate Stripe Payment
+  stripe_element:
+    type: checkbox
+    label: Activated stripe element else paiement with checkout ?
+    help: Do you want to activate Stripe element
   secret_key:
     type: text
     required: true
@@ -12,3 +16,11 @@ config:
     type: text
     required: true
     label: Your publishable key (test or live)
+  webhooks_key:
+    type: text
+    required: true
+    label: Your webhooks secret key (test or live)
+  secure_url:
+    type: text
+    required: true
+    label: Your chose a key for secure webhook return

--- a/Config/config.xml
+++ b/Config/config.xml
@@ -7,6 +7,8 @@
     <hook id="stripepayment.hook" class="StripePayment\Hook\StripePaymentHook" scope="request">
       <tag name="hook.event_listener" event="order-invoice.payment-extra" type="front" method="includeStripe"/>
       <tag name="hook.event_listener" event="order-invoice.after-javascript-include" type="front" method="declareStripeOnClickEvent"/>
+      <tag name="hook.event_listener" event="main.after-javascript-include" type="front" method="includeStripeJsV3"/>
+      <tag name="hook.event_listener" event="main.head-bottom" type="front" method="onMainHeadBottom"/>
     </hook>
   </hooks>
   <services>

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
     <author>
         <name>Etienne Perriere</name>
         <email>eperriere@openstudio.fr</email>

--- a/Config/routing.xml
+++ b/Config/routing.xml
@@ -18,6 +18,10 @@
   <route id="stripepayment.stripe_customer.edit" path="/admin/module/StripePayment/stripe_customer/edit" methods="post">
     <default key="_controller">StripePayment:StripeCustomer:processUpdate</default>
   </route>
+  <route id="stripepayment.stripe_webhooks.listen" path="/module/StripePayment/stripe_webhook/{secure_url}/listen" methods="post">
+    <default key="_controller">StripePayment:StripeWebhooks:listen</default>
+  	<requirement key="secure_url">.*</requirement>
+  </route>
   <route id="stripepayment.stripe_customer.delete" path="/admin/module/StripePayment/stripe_customer/delete" methods="post">
     <default key="_controller">StripePayment:StripeCustomer:delete</default>
   </route>

--- a/Controller/Base/StripePaymentConfigController.php
+++ b/Controller/Base/StripePaymentConfigController.php
@@ -42,10 +42,12 @@ class StripePaymentConfigController extends BaseAdminController
         try {
             $form = $this->validateForm($baseForm);
             $data = $form->getData();
-
             StripePayment::setConfigValue(StripePaymentConfigValue::ENABLED, is_bool($data["enabled"]) ? (int) ($data["enabled"]) : $data["enabled"]);
+            StripePayment::setConfigValue(StripePaymentConfigValue::STRIPE_ELEMENT, is_bool($data["stripe_element"]) ? (int) ($data["stripe_element"]) : $data["stripe_element"]);
             StripePayment::setConfigValue(StripePaymentConfigValue::SECRET_KEY, is_bool($data["secret_key"]) ? (int) ($data["secret_key"]) : $data["secret_key"]);
             StripePayment::setConfigValue(StripePaymentConfigValue::PUBLISHABLE_KEY, is_bool($data["publishable_key"]) ? (int) ($data["publishable_key"]) : $data["publishable_key"]);
+            StripePayment::setConfigValue(StripePaymentConfigValue::WEBHOOKS_KEY, is_bool($data["webhooks_key"]) ? (int) ($data["webhooks_key"]) : $data["webhooks_key"]);
+            StripePayment::setConfigValue(StripePaymentConfigValue::SECURE_URL, is_bool($data["secure_url"]) ? (int) ($data["secure_url"]) : $data["secure_url"]);
         } catch (FormValidationException $ex) {
             // Invalid data entered
             $errorMessage = $this->createStandardFormValidationErrorMessage($ex);

--- a/Controller/StripeWebhooksController.php
+++ b/Controller/StripeWebhooksController.php
@@ -1,0 +1,66 @@
+<?php 
+namespace StripePayment\Controller ;
+
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Thelia\Log\Tlog;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Controller\Front\BaseFrontController;
+use Thelia\Model\ProductQuery;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Thelia\Core\Event\Customer\CustomerCreateOrUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Tools\Password;
+use Thelia\Core\Event\PdfEvent;
+use Thelia\Core\HttpFoundation\Response;
+
+class StripeWebhooksController extends BaseFrontController
+{
+    public function __construct(){}
+	
+	
+	public function listenAction($secure_url){
+		
+		if(StripePayment::getConfigValue('secure_url') == $secure_url){
+			// Set your secret key: remember to change this to your live secret key in production
+			// See your keys here: https://dashboard.stripe.com/account/apikeys
+			\Stripe\Stripe::setApiKey(StripePayment::getConfigValue('secret_key'));
+
+			// You can find your endpoint's secret in your webhook settings
+			$endpoint_secret = StripePayment::getConfigValue('webhooks_key');
+
+			$payload = @file_get_contents('php://input');
+			$sig_header = $_SERVER['HTTP_STRIPE_SIGNATURE'];
+			$event = null;
+
+			try {
+			  $event = \Stripe\Webhook::constructEvent(
+				$payload, $sig_header, $endpoint_secret
+			  );
+			} catch(\UnexpectedValueException $e) {
+			  // Invalid payload
+			  http_response_code(400); // PHP 5.4 or greater
+			  exit();
+			} catch(\Stripe\Error\SignatureVerification $e) {
+			  // Invalid signature
+			  http_response_code(400); // PHP 5.4 or greater
+			  exit();
+			}
+
+			// Handle the checkout.session.completed event
+			if ($event->type == 'checkout.session.completed') {
+			  $session = $event->data->object;
+
+			  // Fulfill the purchase...
+			  // $this->handle_checkout_session($session);
+			}
+
+			http_response_code(200); // PHP 5.4 or greater
+			exit;
+			
+			//if(!empty($_REQUEST["success_url"])) return $response = $this->generateRedirect($_REQUEST["success_url"]);
+		}
+		http_response_code(400); // PHP 5.4 or greater
+		exit();
+	}
+}

--- a/EventListeners/StripePaymentEventListener.php
+++ b/EventListeners/StripePaymentEventListener.php
@@ -10,16 +10,25 @@ use Symfony\Component\HttpFoundation\Request;
 use Thelia\Core\Event\Order\OrderEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\TheliaFormEvent;
+use Thelia\Core\Event\Image\ImageEvent;
 use Thelia\Core\HttpKernel\Exception\RedirectException;
 use Thelia\Core\Template\ParserInterface;
+use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Core\Translation\Translator;
 use Thelia\Log\Tlog;
 use Thelia\Mailer\MailerFactory;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Order as OrderModel;
 use Thelia\Model\OrderStatusQuery;
+use Thelia\Model\OrderProductQuery;
+use Thelia\Model\OrderProductAttributeCombinationQuery;
+use Thelia\Model\ProductImageQuery;
 use Thelia\Tools\URL;
 use Thelia\Model\ModuleQuery;
+use Thelia\Model\ProductQuery;
+use Thelia\Model\OrderCouponQuery;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
  * Class StripePaymentEventListener
@@ -48,7 +57,12 @@ class StripePaymentEventListener implements EventSubscriberInterface
     {
         $events[TheliaEvents::FORM_AFTER_BUILD . ".thelia_order_payment"] = ["addStripeInput", 128];
         $events[TheliaEvents::ORDER_SET_PAYMENT_MODULE] = ["getStripeTokenAndAmount", 128];
+		
         $events[TheliaEvents::ORDER_PAY] = ["stripePayment", 128];
+
+        $events[TheliaEvents::ORDER_SEND_CONFIRMATION_EMAIL] = ["sendConfirmationEmail", 129];
+        $events[TheliaEvents::ORDER_SEND_NOTIFICATION_EMAIL] = ["sendConfirmationEmail", 129];
+
 
         return $events;
     }
@@ -60,8 +74,8 @@ class StripePaymentEventListener implements EventSubscriberInterface
     {
         return $this->mailer;
     }
-
-    /**
+	
+  /**
      * Add stripe_token & stripe_amount inputs to invoice form
      * @param TheliaFormEvent $event
      */
@@ -69,13 +83,8 @@ class StripePaymentEventListener implements EventSubscriberInterface
     {
         $event->getForm()->getFormBuilder()
             ->add(
-                'stripe_token',
+                'stripeToken',
                 'text',
-                ["required" => true]
-            )
-            ->add(
-                'stripe_amount',
-                'integer',
                 ["required" => true]
             );
     }
@@ -85,19 +94,14 @@ class StripePaymentEventListener implements EventSubscriberInterface
      */
     public function getStripeTokenAndAmount()
     {
-        // Get Stripe token
-        $this->request->getSession()->set(
-            'stripeToken',
-            $this->request->get('thelia_order_payment')['stripe_token']
-        );
-
-        // Get order amount
-        $this->request->getSession()->set(
-            'stripeAmount',
-            $this->request->get('thelia_order_payment')['stripe_amount']
-        );
+		if(StripePayment::getConfigValue('stripe_element')){
+			// Get Stripe token
+			$this->request->getSession()->set(
+				'stripeToken',
+				$this->request->get('thelia_order_payment')['stripeToken']
+			);
+		}
     }
-
     /**
      * returns the StripePayment module code
      */
@@ -106,6 +110,14 @@ class StripePaymentEventListener implements EventSubscriberInterface
         return "StripePayment";
     }    
 
+    public function sendConfirmationEmail(OrderEvent $event)
+    {
+		$order = $event->getOrder();
+		if (! $order->isPaid() && $order->getPaymentModuleId() == StripePayment::getModuleId()) {
+			$event->stopPropagation();
+		}
+    }
+	
     /**
      * Send data to Stripe, save token, change order status & get response
      * @param OrderEvent $event
@@ -127,20 +139,21 @@ class StripePaymentEventListener implements EventSubscriberInterface
 
         try {
 
-            // Check order amount
-            $this->checkOrderAmount($order);
+			if(StripePayment::getConfigValue('stripe_element')){
+				// Create the charge on Stripe's servers - this will charge the user's card
+				$this->stripeCharge($order);
+				
+				// Set 'paid' status to the order
+				$this->changeOrderStatus($event);
 
-            // Create the charge on Stripe's servers - this will charge the user's card
-            $this->stripeCharge($order);
-
-            // Save Stripe token into order transaction reference
-            $this->saveStripeToken($order);
-
-            // Set 'paid' status to the order
-            $this->changeOrderStatus($event);
-
-            // Send payment confirmation mail
-            $this->sendConfirmationMail($order);
+				// Send payment confirmation mail
+				$this->sendConfirmationMail($order);
+				
+			}else{
+				// Create the session on Stripe's servers - this will charge the user's order and save session id into order transaction reference
+				$this->stripeSession($order);
+				
+			}
 
         } catch(\Stripe\Error\Card $e) {
             // The card has been declined
@@ -287,25 +300,206 @@ class StripePaymentEventListener implements EventSubscriberInterface
 
     /**
      * Send data to Stripe API & get response
+	 * Save Stripe session as transaction reference
+     * @param OrderModel $order
+     * @return \Stripe\Session
+     */
+    public function stripeSession(OrderModel $order)
+    {
+		$infoItems=array();
+        $this->request->getSession()->set('stripeAmount', 0); // Get order amount
+		$stripeAmount=0;
+		/* Impossible d'ajouter une ligne spécifique pour la remise, cette partie est mise de côté en attendant que stripe ajoute cette possibilité */
+		/* DEBUT CODE PANIER DETAIL
+		$baseSourceFilePath = ConfigQuery::read('images_library_path');
+		if ($baseSourceFilePath === null) {
+			$baseSourceFilePath = THELIA_LOCAL_DIR . 'media' . DS . 'images';
+		} else {
+			$baseSourceFilePath = THELIA_ROOT . $baseSourceFilePath;
+		}
+		if(null !== $orderProducts = OrderProductQuery::create()->filterByOrderId($order->getId())->joinOrderProductTax('opt', Criteria::LEFT_JOIN)->withColumn('SUM(`opt`.AMOUNT)', 'TOTAL_TAX')->withColumn('SUM(`opt`.PROMO_AMOUNT)', 'TOTAL_PROMO_TAX')->groupById()->find()){
+			foreach ($orderProducts as $orderProduct) {
+				$description='';
+				if(null !== $orderProductAttributeCombinations = OrderProductAttributeCombinationQuery::create()->filterByOrderProductId($orderProduct->getId())->find()){
+					foreach ($orderProductAttributeCombinations as $orderProductAttributeCombination) {
+						if($description) $description .= ', ';
+						$description .= $orderProductAttributeCombination->getAttributeTitle() . ' ' . $orderProductAttributeCombination->getAttributeAvTitle();
+					}
+				}
+				$images=array();
+				if(null !== $product = ProductQuery::create()->filterByRef($orderProduct->getProductRef())->findOne()){
+					if(null !== $productImages = ProductImageQuery::create()->filterByProductId($product->getId())->filterByVisible(1)->orderBy('position')->find()){
+						foreach ($productImages as $productImage) {
+							// Put source image file path
+							$sourceFilePath = sprintf(
+								'%s/%s/%s',
+								$baseSourceFilePath,
+								'product',
+								$productImage->getFile()
+							);
+
+							// Create image processing event
+							$event = new ImageEvent();
+							$event->setSourceFilepath($sourceFilePath);
+							$event->setCacheSubdirectory('product');
+							$width=100;
+							try {
+								// Dispatch image processing event
+								$event->setWidth($width);
+								$order->getDispatcher()->dispatch(TheliaEvents::IMAGE_PROCESS, $event);
+								$images[]=$event->getFileUrl();
+							} catch (\Exception $ex) {
+								// Ignore the result and log an error
+								Tlog::getInstance()->addError(sprintf("Failed to process image in image loop: %s", $ex->getMessage()));
+							}
+						}
+					}
+				}
+				if($orderProduct->getWasInPromo()){
+					$amount = $orderProduct->getPromoPrice() + $orderProduct->getVirtualColumn('TOTAL_PROMO_TAX');
+				}else{
+					$amount = $orderProduct->getPrice() + $orderProduct->getVirtualColumn('TOTAL_TAX');
+				}
+				
+				$stripeAmount += $amount * $orderProduct->getQuantity() * 100;
+				$line_items[] = [
+					'name' => $orderProduct->getTitle(),
+					'description' => $description,
+					'images' => $images,
+					'amount' => $amount*100,
+					'currency' => 'eur',
+					'quantity' => $orderProduct->getQuantity(),
+				  ];
+			}
+		}
+		if($order->getPostage()){
+			if(null !== $module = ModuleQuery::create()->findPk($order->getDeliveryModuleId())){
+				$locale = $this->request->getLocale();
+				if($locale == 'en')$locale = 'en_US';
+				$module->setLocale($locale);
+				if(!$module->getTitle())$module->setLocale('fr_FR');
+				$line_items[] = ['name'=> $module->getTitle(), 'description' => $module->getChapo(), 'quantity'=> 1, 'currency' => 'eur', 'amount' => ($order->getPostage()*100)];
+				$stripeAmount += $order->getPostage() * 100;
+			}
+		}
+		*/
+		/*
+		if($order->getDiscount() > 0){
+			echo $order->getDiscount();
+			$description=null;
+			if(null !== $orderCoupons = OrderCouponQuery::create()->filterByOrderId($order->getId())->find()){
+				foreach($orderCoupons as $orderCoupon){
+					if($description)$description .= ', ';
+					$description .= $orderCoupon->getTitle();
+				}
+			}
+			$line_items[] = ['name'=> Translator::getInstance()->trans('Discount', [], StripePayment::MESSAGE_DOMAIN ), 'description' => $description, 'quantity'=> -1, 'currency' => 'eur', 'amount' => ($order->getDiscount()*100)];
+				$stripeAmount -= $order->getDiscount() * 100;
+		}
+		*/
+		// FIN CODE PANIER DETAIL
+		/* à la place le montant sera envoyé en une seul ligne sans détail */
+		$stripeAmount = $order->getTotalAmount() * 100;
+		$line_items[] = ['name'=> Translator::getInstance()->trans('Total', [], StripePayment::MESSAGE_DOMAIN ), 'description' => null, 'quantity'=> 1, 'currency' => 'eur', 'amount' => $stripeAmount];
+				
+		$this->request->getSession()->set('stripeAmount', $stripeAmount); // Get order amount
+
+		// Check order amount
+		$this->checkOrderAmount($order);
+		
+		if(!empty($line_items)){
+			try{
+				// $message = $userMessage = Translator::getInstance()->trans('An error occurred during payment.', [], StripePayment::MESSAGE_DOMAIN );
+				/* Le message d'erreur rend le cancel_url invalid */
+				$message = 'error';
+				$session = \Stripe\Checkout\Session::create([
+				  'customer_email' => $order->getCustomer()->getEmail(),
+				  'client_reference_id' => $order->getRef(),
+				  'payment_method_types' => ['card'],
+				  'line_items' => $line_items,
+				  'success_url' => URL::getInstance()->absoluteUrl('/order/placed/' . $order->getId()),
+				  'cancel_url' => URL::getInstance()->absoluteUrl('/order/failed/' . $order->getId() . '/' . $message),
+				]);
+
+				$this->request->getSession()->set('checkout_session_id', $session->id); // Get session id
+				$order->setTransactionRef($session->id)->save();
+				
+				
+				$this->parser->setTemplateDefinition(new TemplateDefinition('default',1));
+				/* Je ne suis pas sur que ce soit la meilleur méthode. */
+			 	echo $this->parser->render(
+					'stripe-paiement.html',
+					[
+						'checkout_session_id' => $session->id,
+						'public_key' => StripePayment::getConfigValue('publishable_key')
+					]
+				);
+				exit;
+			}
+		  	catch (Exception $e) {
+				$error = $e->getMessage();
+				$_REQUEST['erreurpaiement']=1;
+				$_REQUEST['erreurpaiementmsg']=$error;
+			}
+		}
+    }
+
+    /**
+     * Send data to Stripe API & get response
      * @param OrderModel $order
      * @return \Stripe\Charge
      */
     public function stripeCharge(OrderModel $order)
     {
-        $stripeApiCustomer = \Stripe\Customer::create(
-            [
-                'email' => $order->getCustomer()->getEmail(),
-                'card' =>  $this->request->getSession()->get('stripeToken')
-            ]
-        );
-
-        \Stripe\Charge::create(
+		// Token is created using Checkout or Elements!
+		// Get the payment token ID submitted by the form:
+		$token = $this->request->getSession()->get('stripeToken');
+		$customerStripe=null;
+		$stripeApiCustomerRetrieves = \Stripe\Customer::all(['limit' => 1, 'email' => $order->getCustomer()->getEmail()]);
+		foreach($stripeApiCustomerRetrieves->data as $stripeApiCustomerRetrieve){
+			$customerStripe = $stripeApiCustomerRetrieve;
+		}
+		
+		if($customerStripe){
+			$stripeApiCustomer = \Stripe\Customer::update(
+			  $customerStripe->id,
+			  [
+				'source' =>  $token,
+				'address' => [
+					'line1'=> $order->getOrderAddressRelatedByDeliveryOrderAddressId()->getAddress1(),
+					'city'=> $order->getOrderAddressRelatedByDeliveryOrderAddressId()->getCity(),
+					'country'=> $order->getOrderAddressRelatedByDeliveryOrderAddressId()-> getCountry()->getTranslation()->getTitle(),
+					'line2'=> $order->getOrderAddressRelatedByDeliveryOrderAddressId()->getAddress2(),
+					'postal_code'=> $order->getOrderAddressRelatedByDeliveryOrderAddressId()->getZipcode(),
+				]
+			  ]
+			);	
+		}else{
+			$stripeApiCustomer = \Stripe\Customer::create(
+				[
+					'email' => $order->getCustomer()->getEmail(),
+					'source' =>  $token,
+					'address' => [
+						'line1'=> $order->getOrderAddressRelatedByDeliveryOrderAddressId()->getAddress1(),
+						'city'=> $order->getOrderAddressRelatedByDeliveryOrderAddressId()->getCity(),
+						'country'=> $order->getOrderAddressRelatedByDeliveryOrderAddressId()-> getCountry()->getTranslation()->getTitle(),
+						'line2'=> $order->getOrderAddressRelatedByDeliveryOrderAddressId()->getAddress2(),
+						'postal_code'=> $order->getOrderAddressRelatedByDeliveryOrderAddressId()->getZipcode(),
+					]
+				]
+			);
+		}
+        $retour = \Stripe\Charge::create(
             [
                 'customer' => $stripeApiCustomer,
                 'amount' => $order->getTotalAmount() * 100,
-                'currency' => $order->getCurrency()->getCode()
+                'currency' => $order->getCurrency()->getCode(),
+				'description' => 'Order ' . $order->getRef(),
+				'source' => $stripeApiCustomer->default_source,
+				'metadata' => ['order_id' => $order->getId(), 'order_ref' => $order->getRef()],
             ]
         );
+		$order->setTransactionRef($retour->id)->save();
     }
 
     /**

--- a/Form/Base/StripePaymentConfigForm.php
+++ b/Form/Base/StripePaymentConfigForm.php
@@ -46,8 +46,11 @@ class StripePaymentConfigForm extends BaseForm
         $fieldsIdKeys = $this->getFieldsIdKeys();
 
         $this->addEnabledField($translationKeys, $fieldsIdKeys);
+        $this->addStripeElementField($translationKeys, $fieldsIdKeys);
         $this->addSecretKeyField($translationKeys, $fieldsIdKeys);
         $this->addPublishableKeyField($translationKeys, $fieldsIdKeys);
+        $this->addWebhooksKeyField($translationKeys, $fieldsIdKeys);
+        $this->addSecureUrlField($translationKeys, $fieldsIdKeys);
     }
 
     protected function addEnabledField(array $translationKeys, array $fieldsIdKeys)
@@ -63,6 +66,22 @@ class StripePaymentConfigForm extends BaseForm
                 "constraints" => array(
                 ),
                 "value" => StripePayment::getConfigValue(StripePaymentConfigValue::ENABLED, false),
+            ))
+        ;
+    }
+    protected function addStripeElementField(array $translationKeys, array $fieldsIdKeys)
+    {
+        $this->formBuilder
+            ->add("stripe_element", "checkbox", array(
+                "label" => $this->readKey("stripe_element", $translationKeys),
+                "label_attr" => [
+                    "for" => $this->readKey("stripeelementch", $fieldsIdKeys),
+                    "help" => $this->readKey("help.stripe_element", $translationKeys)
+                ],
+                "required" => false,
+                "constraints" => array(
+                ),
+                "value" => StripePayment::getConfigValue(StripePaymentConfigValue::STRIPE_ELEMENT, false),
             ))
         ;
     }
@@ -103,6 +122,41 @@ class StripePaymentConfigForm extends BaseForm
         ;
     }
 
+    protected function addWebhooksKeyField(array $translationKeys, array $fieldsIdKeys)
+    {
+        $this->formBuilder
+            ->add("webhooks_key", "text", array(
+                "label" => $this->readKey("webhooks_key", $translationKeys),
+                "label_attr" => [
+                    "for" => $this->readKey("webhooks_key", $fieldsIdKeys),
+                    "help" => $this->readKey("help.webhooks_key", $translationKeys)
+                ],
+                "required" => true,
+                "constraints" => array(
+                    new NotBlank(),
+                ),
+                "data" => StripePayment::getConfigValue(StripePaymentConfigValue::WEBHOOKS_KEY),
+            ))
+        ;
+    }
+    protected function addSecureUrlField(array $translationKeys, array $fieldsIdKeys)
+    {
+        $this->formBuilder
+            ->add("secure_url", "text", array(
+                "label" => $this->readKey("secure_url", $translationKeys),
+                "label_attr" => [
+                    "for" => $this->readKey("secure_url", $fieldsIdKeys),
+                    "help" => $this->readKey("help.secure_url", $translationKeys)
+                ],
+                "required" => true,
+                "constraints" => array(
+                    new NotBlank(),
+                ),
+                "data" => StripePayment::getConfigValue(StripePaymentConfigValue::SECURE_URL),
+            ))
+        ;
+    }
+
     public function getName()
     {
         return static::FORM_NAME;
@@ -127,7 +181,9 @@ class StripePaymentConfigForm extends BaseForm
         return array(
             "enabled" => "enabled",
             "secret_key" => "secret_key",
-            "publishable_key" => "publishable_key"
+            "publishable_key" => "publishable_key",
+            "webhooks_key" => "webhooks_key",
+            "secure_url" => "secure_url"
         );
     }
 }

--- a/Form/StripePaymentConfigForm.php
+++ b/Form/StripePaymentConfigForm.php
@@ -19,8 +19,11 @@ class StripePaymentConfigForm extends BaseStripePaymentConfigForm
     {
         return array(
             "enabled" => $this->translator->trans("Activated ?", [], StripePayment::MESSAGE_DOMAIN),
+            "stripe_element" => $this->translator->trans("Activated stripe element ?", [], StripePayment::MESSAGE_DOMAIN),
             "secret_key" => $this->translator->trans("Your secret key", [], StripePayment::MESSAGE_DOMAIN),
             "publishable_key" => $this->translator->trans("Your publishable key (test or live)", [], StripePayment::MESSAGE_DOMAIN),
+            "webhooks_key" => $this->translator->trans("Your webhooks key", [], StripePayment::MESSAGE_DOMAIN),
+            "secure_url" => $this->translator->trans("Your chaine of char for secure return webhook", [], StripePayment::MESSAGE_DOMAIN),
             "help.enabled" => $this->translator->trans("Do you want to activate Stripe Payment", [], StripePayment::MESSAGE_DOMAIN),
             "help.secret_key" => $this->translator->trans("You can see all your keys in your <a target=\"_blank\" href=\"https://dashboard.stripe.com/\">Stripe dashboard</a>. Also note that you can place your test or your live API keys", [], StripePayment::MESSAGE_DOMAIN),
         );

--- a/Hook/StripePaymentHook.php
+++ b/Hook/StripePaymentHook.php
@@ -15,27 +15,38 @@ class StripePaymentHook extends BaseHook
 {
     public function includeStripe(HookRenderEvent $event)
     {
-        $publicKey = StripePayment::getConfigValue('publishable_key');
-
-        $event->add($this->render(
-            'assets/js/stripe-js.html',
-            [
-                'stripe_module_id' => $this->getModule()->getModuleId(),
-                'public_key' => $publicKey
-            ]
-        ));
+		if(StripePayment::getConfigValue('stripe_element')){
+			$publicKey = StripePayment::getConfigValue('publishable_key');
+			$event->add($this->render(
+				'assets/js/stripe-js.html',
+				[
+					'stripe_module_id' => $this->getModule()->getModuleId(),
+					'public_key' => $publicKey
+				]
+			));
+		}
     }
 
     public function declareStripeOnClickEvent(HookRenderEvent $event)
     {
-        $publicKey = StripePayment::getConfigValue('publishable_key');
-
-        $event->add($this->render(
-            'assets/js/order-invoice-after-js-include.html',
-            [
-                'stripe_module_id' => $this->getModule()->getModuleId(),
-                'public_key' => $publicKey
-            ]
-        ));
+		if(StripePayment::getConfigValue('stripe_element')){
+			$publicKey = StripePayment::getConfigValue('publishable_key');
+			$event->add($this->render(
+				'assets/js/order-invoice-after-js-include.html',
+				[
+					'stripe_module_id' => $this->getModule()->getModuleId(),
+					'public_key' => $publicKey
+				]
+			));
+		}
+    }
+    public function includeStripeJsV3(HookRenderEvent $event)
+    {
+        $event->add('<script src="https://js.stripe.com/v3/"></script>');
+    }
+	public function onMainHeadBottom(HookRenderEvent $event)
+    {
+        $content = $this->addCSS('assets/css/styles.css');
+        $event->add($content);
     }
 }

--- a/Model/Config/Base/StripePaymentConfigValue.php
+++ b/Model/Config/Base/StripePaymentConfigValue.php
@@ -19,7 +19,10 @@ namespace StripePayment\Model\Config\Base;
 class StripePaymentConfigValue
 {
     const ENABLED = "enabled";
+    const STRIPE_ELEMENT = "stripe_element";
     const SECRET_KEY = "secret_key";
     const PUBLISHABLE_KEY = "publishable_key";
+    const WEBHOOKS_KEY = "webhooks_key";
+    const SECURE_URL = "secure_url";
 }
 

--- a/Update.md
+++ b/Update.md
@@ -1,0 +1,17 @@
+Nouvelle version des fichier API
+
+Deux manières différente de pouvoir payer. 
+Avec Element (avoir le formulaire de paiement directement sur le site), avec Checkout (être redirigé sur le site de stripe)
+
+Choix dans l'administration sur qu'elle solution le site fonctionne. 
+
+Il faut vérifier les modifications et peut-être améliorer ou deplacer certaines parties. 
+Je me demande si le \Stripe\Checkout\Session ne devrait pas être ailleurs que dans un listerner ?
+
+Le webhook de stripe est utilisé pour passer la commande en payé quand on utilise le checkout.
+
+
+Sur element quand on a le formulaire de paiement sur le site, il faudrait faire la partie qui permet d'afficher le bouton "apple pay" ou "google pay" (j'ai mis que le code html pour le moment)
+	<div id="payment-request-button">
+	  <!-- A Stripe Element will be inserted here. -->
+	</div>

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "thelia-module",
   "require": {
     "thelia/installer": "~1.1",
-    "stripe/stripe-php": "3.*"
+    "stripe/stripe-php": "6.*"
   },
   "extra": {
     "installer-name": "StripePayment"

--- a/templates/backOffice/default/stripepayment-configuration.html
+++ b/templates/backOffice/default/stripepayment-configuration.html
@@ -60,6 +60,24 @@
                                 {/if}
                             </div>
                             {/form_field}
+                            {form_field form=$form field="stripe_element"}
+                            <div class="form-group {if $error}has-error{/if}">
+                                <label class="control-label" for="{$label_attr.for}">
+                                    <input type="checkbox" name="{$name}" id="{$label_attr.for}" {if $value}checked{/if} placeholder="{intl l='active stripe element' d="stripepayment.bo.default"}" />
+                                    {$label}
+                                    {if $required}<span class="required">*</span>{/if}
+
+                                    {form_error form=$form field="stripe_element"}
+                                    <br />
+                                    <span class="error">{$message}</span>
+                                    {/form_error}
+                                </label>
+
+                                {if ! empty($label_attr.help)}
+                                    <span class="help-block">{$label_attr.help}</span>
+                                {/if}
+                            </div>
+                            {/form_field}
                             {form_field form=$form field="secret_key"}
                             <div class="form-group {if $error}has-error{/if}">
                                 <label class="control-label" for="{$label_attr.for}">
@@ -96,7 +114,51 @@
                                 {/if}
                             </div>
                             {/form_field}
+							
+							{form_field form=$form field="webhooks_key"}
+                            <div class="form-group {if $error}has-error{/if}">
+                                <label class="control-label" for="{$label_attr.for}">
+                                    {$label}
+                                    {if $required}<span class="required">*</span>{/if}
 
+                                    {form_error form=$form field="webhooks_key"}
+                                    <br />
+                                    <span class="error">{$message}</span>
+                                    {/form_error}
+                                </label>
+
+                                <input type="text" class="form-control" name="{$name}" id="{$label_attr.for}" value="{$value}" placeholder="{intl l='The configuration value webhooks_key whsec_...' d="stripepayment.bo.default"}" />
+                                {if ! empty($label_attr.help)}
+                                    <span class="help-block">{$label_attr.help}</span>
+                                {/if}
+                            </div>
+                            {/form_field}
+
+							{form_field form=$form field="secure_url"}
+                            <div class="form-group {if $error}has-error{/if}">
+                                <label class="control-label" for="{$label_attr.for}">
+                                    {$label}
+                                    {if $required}<span class="required">*</span>{/if}
+
+                                    {form_error form=$form field="secure_url"}
+                                    <br />
+                                    <span class="error">{$message}</span>
+                                    {/form_error}
+                                </label>
+
+                                <input type="text" class="form-control" name="{$name}" id="{$label_attr.for}" value="{$value}" placeholder="{intl l='The configuration value secure_url' d="stripepayment.bo.default"}" />
+                                {if ! empty($label_attr.help)}
+                                    <span class="help-block">{$label_attr.help}</span>
+                                {/if}
+                            </div>
+							
+								<p>URL d'endpoint pour checkout.session.completed<br>
+									{url path="/module/StripePayment/stripe_webhook/{$value}/listen"}
+								</p>
+								
+							
+                            {/form_field}
+							
                             {include "includes/inner-form-toolbar.html" hide_flags = 1 close_url={url path='/admin/modules'} page_bottom = 1}
                         </form>
                     {/form}

--- a/templates/frontOffice/default/assets/css/styles.css
+++ b/templates/frontOffice/default/assets/css/styles.css
@@ -1,0 +1,31 @@
+/**
+ * The CSS shown here will not be introduced in the Quickstart guide, but shows
+ * how you can use CSS to style your Element's container.
+ */
+.StripeElement {
+  box-sizing: border-box;
+
+  height: 40px;
+
+  padding: 10px 12px;
+
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background-color: white;
+
+  box-shadow: 0 1px 3px 0 #e6ebf1;
+  -webkit-transition: box-shadow 150ms ease;
+  transition: box-shadow 150ms ease;
+}
+
+.StripeElement--focus {
+  box-shadow: 0 1px 3px 0 #cfd7df;
+}
+
+.StripeElement--invalid {
+  border-color: #fa755a;
+}
+
+.StripeElement--webkit-autofill {
+  background-color: #fefde5 !important;
+}

--- a/templates/frontOffice/default/assets/js/order-invoice-after-js-include.html
+++ b/templates/frontOffice/default/assets/js/order-invoice-after-js-include.html
@@ -1,50 +1,72 @@
 <script>
+	// Create a Stripe client.
+	var stripe = Stripe('{$public_key}');
 
-    // Stripe handler
-    var handler = StripeCheckout.configure({
-        key: '{$public_key}',
-        locale: 'auto',
-        token: function(token) {
-            // When Stripe card form is submitted, get Stripe token
-            $("#stripe_token").val(token.id);
+	// Create an instance of Elements.
+	var elements = stripe.elements();
 
-            // Submit invoice form
-            $("#form-cart-payment").submit();
-        }
-    });
+	// Custom styling can be passed to options when creating an Element.
+	// (Note that this demo uses a wider set of styles than the guide below.)
+	var style = {
+	  base: {
+		color: '#32325d',
+		fontFamily: '"Helvetica Neue", Helvetica, sans-serif',
+		fontSmoothing: 'antialiased',
+		fontSize: '16px',
+		'::placeholder': {
+		  color: '#aab7c4'
+		}
+	  },
+	  invalid: {
+		color: '#fa755a',
+		iconColor: '#fa755a'
+	  }
+	};
 
-    // When payment form is submitted
-    $('#form-cart-payment').on('submit', function (e) {
+	// Create an instance of the card Element.
+	var card = elements.create('card', { style: style });
 
-        // If Stripe is selected
-        if ($('form#form-cart-payment input#payment_{$stripe_module_id}').is(':checked')) {
+	// Add an instance of the card Element into the `card-element` <div>.
+	card.mount('#card-element');
 
-            // If Stripe token is filled, prepare data to be displayed in Stripe card form
-            if ($("#stripe_token").val() == '') {
+	// Handle real-time validation errors from the card Element.
+	card.addEventListener('change', function(event) {
+	  var displayError = document.getElementById('card-errors');
+	  if (event.error) {
+		displayError.textContent = event.error.message;
+	  } else {
+		displayError.textContent = '';
+	  }
+	});
 
-                // Get currency and format order amount for Stripe
-                var currency = '{{currency attr="code"}|lower}';
-                var totalAmount = {{{{cart attr="total_taxed_price"} + {order attr="postage"}}*100}|round:0};
+	// Handle form submission.
+	var form = document.getElementById('form-cart-payment');
+	form.addEventListener('submit', function(event) {
+	  event.preventDefault();
 
-                // Get order amount (in case once Stripe popup is displayed, the customer adds or removes a product from another tab)
-                $("#stripe_amount").val(totalAmount);
+	  stripe.createToken(card).then(function(result) {
+		if (result.error) {
+		  // Inform the user if there was an error.
+		  var errorElement = document.getElementById('card-errors');
+		  errorElement.textContent = result.error.message;
+		} else {
+		  // Send the token to your server.
+		  stripeTokenHandler(result.token);
+		}
+	  });
+	});
 
-                // Open Checkout with further options
-                handler.open({
-                    name: '{config key="store_name"}',
-                    currency: currency,
-                    amount: totalAmount,
-                    email: '{customer attr="email"}',
-                    allowRememberMe: false
-                });
+	// Submit the form with the token ID.
+	function stripeTokenHandler(token) {
+	  // Insert the token ID into the form so it gets submitted to the server
+	  var form = document.getElementById('form-cart-payment');
+	  var hiddenInput = document.createElement('input');
+	  hiddenInput.setAttribute('type', 'hidden');
+	  hiddenInput.setAttribute('name', 'thelia_order_payment[stripeToken]');
+	  hiddenInput.setAttribute('value', token.id);
+	  form.appendChild(hiddenInput);
 
-                e.preventDefault();
-            }
-        }
-    });
-
-    // Close Checkout on page navigation
-    $(window).on('popstate', function () {
-        handler.close();
-    });
+	  // Submit the form
+	  form.submit();
+	}
 </script>

--- a/templates/frontOffice/default/assets/js/stripe-js.html
+++ b/templates/frontOffice/default/assets/js/stripe-js.html
@@ -1,4 +1,13 @@
-<input type="hidden" name="thelia_order_payment[stripe_token]" id="stripe_token" value="">
-<input type="hidden" name="thelia_order_payment[stripe_amount]" id="stripe_amount" value="">
-
-<script src="https://checkout.stripe.com/checkout.js"></script>
+<div class="form-row" >
+	<label for="card-element">
+		{intl l="Credit or debit card"}
+	</label>
+	<div id="card-element">
+	<!-- A Stripe Element will be inserted here. -->
+	</div>
+	<div id="payment-request-button">
+	  <!-- A Stripe Element will be inserted here. -->
+	</div>
+	<!-- Used to display form errors. -->
+	<div id="card-errors" role="alert"></div>
+</div>

--- a/templates/frontOffice/default/stripe-paiement.html
+++ b/templates/frontOffice/default/stripe-paiement.html
@@ -1,0 +1,17 @@
+ici
+<script src="https://js.stripe.com/v3/"></script>
+<script>
+var stripe = Stripe('{$public_key}');
+stripe.redirectToCheckout({
+	{literal}
+  // Make the id field from the Checkout Session creation API response
+  // available to this file, so you can provide it as parameter here
+  // instead of the {{CHECKOUT_SESSION_ID}} placeholder.
+  {/literal}
+  sessionId: '{$checkout_session_id}'
+}).then(function (result) {
+  // If `redirectToCheckout` fails due to a browser or network
+  // error, display the localized error message to your customer
+  // using `result.error.message`.
+});
+</script>


### PR DESCRIPTION
Nouvelle version des fichier API

Deux manières différente de pouvoir payer.
Avec Element (avoir le formulaire de paiement directement sur le site), avec Checkout (être redirigé sur le site de stripe)

Choix dans l'administration sur qu'elle solution le site fonctionne.

Il faut vérifier les modifications et peut-être améliorer ou deplacer certaines parties.
Je me demande si le \Stripe\Checkout\Session ne devrait pas être ailleurs que dans un listerner ?

Le webhook de stripe est utilisé pour passer la commande en payé quand on utilise le checkout.

Sur element quand on a le formulaire de paiement sur le site, il faudrait faire la partie qui permet d'afficher le bouton "apple pay" ou "google pay" (j'ai mis que le code html pour le moment)
	<div id="payment-request-button">
	  <!-- A Stripe Element will be inserted here. -->
	</div>