### PR TITLE
feat: Stripe SDK v20 + Dashboard-driven payment method selection (4.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [4.0.0] - 2026-04-27
+
+### Changed
+
+- **BREAKING**: bumped `stripe/stripe-php` requirement from `^7.100` to `^20.0`.
+- `createStripeSession()` no longer hard-codes `payment_method_types=['card']`.
+  Payment-method selection is now resolved at call time with a 3-tier priority:
+  CSV override > Payment Method Configuration id > Stripe Dashboard default.
+- Replaced the long-removed `\Stripe\Error\SignatureVerification` alias with
+  `\Stripe\Exception\SignatureVerificationException` in the webhook controller.
+
+### Added
+
+- Two back-office configuration fields:
+  - `payment_method_types_override` (CSV) — explicit, highest priority.
+  - `payment_method_configuration_id` (`pmc_xxx`) — Dashboard-driven config.
+- `update()` hook that seeds `payment_method_types_override="card"` when
+  upgrading from any pre-4.0 version, preserving the previous behavior.
+- README section documenting the three payment-method selection modes and
+  the migration path from 3.x.
+
+### Migration
+
+Upgrading existing installs is non-breaking at runtime: the update hook
+keeps the legacy card-only behavior. To benefit from the modern flow,
+clear the override field (or set a Payment Method Configuration id) in the
+Stripe configuration page of the Thelia back-office.
+
+## [3.1.0] - 2026-04
+
+### Fixed
+
+- Stripe payment logging path falls back to `var/log/`.
+- Swapped fr_FR translations restored.
+- Rich Stripe exception details (request_id, code, http_status) in logs.
+- Log payload before sending to Stripe; log rotation by file size.
+- `chmod 0666` on freshly created log file; webhook event dumped as JSON.

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>3.1.0</version>
+    <version>4.0.0</version>
     <author>
         <name>Etienne Perriere</name>
         <email>eperriere@openstudio.fr</email>

--- a/Controller/StripePaymentConfigController.php
+++ b/Controller/StripePaymentConfigController.php
@@ -48,6 +48,8 @@ class StripePaymentConfigController extends BaseAdminController
             StripePayment::setConfigValue(StripePayment::PUBLISHABLE_KEY, is_bool($data["publishable_key"]) ? (int) ($data["publishable_key"]) : $data["publishable_key"]);
             StripePayment::setConfigValue(StripePayment::WEBHOOKS_KEY, is_bool($data["webhooks_key"]) ? (int) ($data["webhooks_key"]) : $data["webhooks_key"]);
             StripePayment::setConfigValue(StripePayment::SECURE_URL, is_bool($data["secure_url"]) ? (int) ($data["secure_url"]) : $data["secure_url"]);
+            StripePayment::setConfigValue(StripePayment::STRIPE_PMC_TYPES_OVERRIDE, trim((string) ($data["payment_method_types_override"] ?? '')));
+            StripePayment::setConfigValue(StripePayment::CONFIG_PMC_ID, trim((string) ($data["payment_method_configuration_id"] ?? '')));
         } catch (FormValidationException $ex) {
             // Invalid data entered
             $errorMessage = $this->createStandardFormValidationErrorMessage($ex);

--- a/Controller/StripeWebHooksController.php
+++ b/Controller/StripeWebHooksController.php
@@ -3,7 +3,7 @@
 namespace StripePayment\Controller;
 
 use Stripe\Checkout\Session;
-use Stripe\Error\SignatureVerification;
+use Stripe\Exception\SignatureVerificationException;
 use Stripe\Stripe;
 use Stripe\Webhook;
 use StripePayment\Classes\StripePaymentLog;
@@ -88,7 +88,7 @@ class StripeWebHooksController extends BaseFrontController
                     StripePaymentLog::ERROR
                 );
                 return new Response('Invalid payload', 400);
-            } catch (SignatureVerification $e) {
+            } catch (SignatureVerificationException $e) {
                 (new StripePaymentLog())->logText(
                     sprintf('Webhook signature verification failed: %s', $e->getMessage()),
                     StripePaymentLog::ERROR

--- a/Form/Base/StripePaymentConfigForm.php
+++ b/Form/Base/StripePaymentConfigForm.php
@@ -11,6 +11,8 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Thelia\Form\BaseForm;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Regex;
 
 /**
  * Class StripePaymentConfigForm
@@ -53,6 +55,8 @@ class StripePaymentConfigForm extends BaseForm
         $this->addPublishableKeyField($translationKeys, $fieldsIdKeys);
         $this->addWebhooksKeyField($translationKeys, $fieldsIdKeys);
         $this->addSecureUrlField($translationKeys, $fieldsIdKeys);
+        $this->addPaymentMethodTypesOverrideField($translationKeys, $fieldsIdKeys);
+        $this->addPaymentMethodConfigurationIdField($translationKeys, $fieldsIdKeys);
     }
 
     protected function addEnabledField(array $translationKeys, array $fieldsIdKeys)
@@ -176,6 +180,45 @@ class StripePaymentConfigForm extends BaseForm
         ;
     }
 
+    protected function addPaymentMethodTypesOverrideField(array $translationKeys, array $fieldsIdKeys)
+    {
+        $this->formBuilder
+            ->add("payment_method_types_override", TextType::class, array(
+                "label" => $this->readKey("payment_method_types_override", $translationKeys),
+                "label_attr" => [
+                    "for" => $this->readKey("payment_method_types_override", $fieldsIdKeys),
+                    "help" => $this->readKey("help.payment_method_types_override", $translationKeys)
+                ],
+                "required" => false,
+                "constraints" => array(
+                    new Regex([
+                        'pattern' => '/^[a-z0-9_]+(\s*,\s*[a-z0-9_]+)*$/',
+                        'message' => 'Comma-separated list of Stripe payment method type identifiers (e.g. "card,twint").',
+                    ]),
+                ),
+                "data" => StripePayment::getConfigValue(StripePayment::STRIPE_PMC_TYPES_OVERRIDE),
+            ))
+        ;
+    }
+
+    protected function addPaymentMethodConfigurationIdField(array $translationKeys, array $fieldsIdKeys)
+    {
+        $this->formBuilder
+            ->add("payment_method_configuration_id", TextType::class, array(
+                "label" => $this->readKey("payment_method_configuration_id", $translationKeys),
+                "label_attr" => [
+                    "for" => $this->readKey("payment_method_configuration_id", $fieldsIdKeys),
+                    "help" => $this->readKey("help.payment_method_configuration_id", $translationKeys)
+                ],
+                "required" => false,
+                "constraints" => array(
+                    new Length(['max' => 100]),
+                ),
+                "data" => StripePayment::getConfigValue(StripePayment::CONFIG_PMC_ID),
+            ))
+        ;
+    }
+
     public static function getName()
     {
         return static::FORM_NAME;
@@ -202,7 +245,9 @@ class StripePaymentConfigForm extends BaseForm
             "secret_key" => "secret_key",
             "publishable_key" => "publishable_key",
             "webhooks_key" => "webhooks_key",
-            "secure_url" => "secure_url"
+            "secure_url" => "secure_url",
+            "payment_method_types_override" => "payment_method_types_override",
+            "payment_method_configuration_id" => "payment_method_configuration_id",
         );
     }
 }

--- a/Form/StripePaymentConfigForm.php
+++ b/Form/StripePaymentConfigForm.php
@@ -25,9 +25,13 @@ class StripePaymentConfigForm extends BaseStripePaymentConfigForm
             "publishable_key" => $this->translator->trans("Your publishable key (test or live)", [], StripePayment::MESSAGE_DOMAIN),
             "webhooks_key" => $this->translator->trans("Your webhooks key", [], StripePayment::MESSAGE_DOMAIN),
             "secure_url" => $this->translator->trans("Your chain of char for secure return webhook", [], StripePayment::MESSAGE_DOMAIN),
+            "payment_method_types_override" => $this->translator->trans("Payment method types override (CSV)", [], StripePayment::MESSAGE_DOMAIN),
+            "payment_method_configuration_id" => $this->translator->trans("Payment method configuration ID", [], StripePayment::MESSAGE_DOMAIN),
             "help.enabled" => $this->translator->trans("Do you want to activate Stripe Payment", [], StripePayment::MESSAGE_DOMAIN),
             "help.stripe_element" => $this->translator->trans("Element is the embedded and customizable payment form", [], StripePayment::MESSAGE_DOMAIN),
             "help.secret_key" => $this->translator->trans("You can see all your keys in your <a target=\"_blank\" href=\"https://dashboard.stripe.com/\">Stripe dashboard</a>. Also note that you can place your test or your live API keys", [], StripePayment::MESSAGE_DOMAIN),
+            "help.payment_method_types_override" => $this->translator->trans("Comma-separated Stripe payment method type identifiers (e.g. <code>card,twint</code>). When set, this overrides the Dashboard configuration. Highest priority.", [], StripePayment::MESSAGE_DOMAIN),
+            "help.payment_method_configuration_id" => $this->translator->trans("Stripe Payment Method Configuration ID (e.g. <code>pmc_xxx</code>). Used when the override field is empty. Falls back to the Dashboard default if both are empty.", [], StripePayment::MESSAGE_DOMAIN),
         );
     }
 }

--- a/I18n/backOffice/default/en_US.php
+++ b/I18n/backOffice/default/en_US.php
@@ -9,4 +9,6 @@ return array(
     'The configuration value enabled' => 'The configuration value enabled',
     'The configuration value publishable_key' => 'The configuration value publishable_key',
     'The configuration value secret_key' => 'The configuration value secret_key',
+    'The configuration value payment_method_types_override' => 'card,twint (leave empty to use the Stripe Dashboard)',
+    'The configuration value payment_method_configuration_id' => 'pmc_xxx (leave empty to use the Stripe Dashboard)',
 );

--- a/I18n/backOffice/default/fr_FR.php
+++ b/I18n/backOffice/default/fr_FR.php
@@ -11,6 +11,8 @@ return array(
     'The configuration value secret_key' => 'La valeur de configuration "secret_key"',
     'The configuration value secure_url' => 'La valeur de configuration secure_url',
     'The configuration value webhooks_key whsec_...' => 'La valeur de configuration webhooks_key whsec_...',
+    'The configuration value payment_method_types_override' => 'card,twint (laisser vide pour utiliser le Dashboard Stripe)',
+    'The configuration value payment_method_configuration_id' => 'pmc_xxx (laisser vide pour utiliser le Dashboard Stripe)',
     'Webhooks endpoint url' => 'URL d\'endpoint WebHook',
     'Webhooks event to activate' => 'Événements WebHook à activer',
     'active stripe element' => 'Activer Stripe Element',

--- a/I18n/en_US.php
+++ b/I18n/en_US.php
@@ -18,4 +18,8 @@ return array(
     'Your card has been declined.' => 'Your card has been declined.',
     'Your publishable key (test or live)' => 'Your publishable key (test or live)',
     'Your secret key' => 'Your secret key',
+    'Payment method types override (CSV)' => 'Payment method types override (CSV)',
+    'Payment method configuration ID' => 'Payment method configuration ID',
+    'Comma-separated Stripe payment method type identifiers (e.g. <code>card,twint</code>). When set, this overrides the Dashboard configuration. Highest priority.' => 'Comma-separated Stripe payment method type identifiers (e.g. <code>card,twint</code>). When set, this overrides the Dashboard configuration. Highest priority.',
+    'Stripe Payment Method Configuration ID (e.g. <code>pmc_xxx</code>). Used when the override field is empty. Falls back to the Dashboard default if both are empty.' => 'Stripe Payment Method Configuration ID (e.g. <code>pmc_xxx</code>). Used when the override field is empty. Falls back to the Dashboard default if both are empty.',
 );

--- a/I18n/fr_FR.php
+++ b/I18n/fr_FR.php
@@ -26,4 +26,8 @@ return array(
     'Your publishable key (test or live)' => 'Votre clé publique',
     'Your secret key' => 'Votre clé secrète',
     'Your webhooks key' => 'Votre clé Webhooks ?',
+    'Payment method types override (CSV)' => 'Surcharge des moyens de paiement (CSV)',
+    'Payment method configuration ID' => 'ID de configuration des moyens de paiement',
+    'Comma-separated Stripe payment method type identifiers (e.g. <code>card,twint</code>). When set, this overrides the Dashboard configuration. Highest priority.' => 'Liste CSV des identifiants de moyens de paiement Stripe (par ex. <code>card,twint</code>). Si renseigné, surcharge la configuration du Dashboard. Priorité maximale.',
+    'Stripe Payment Method Configuration ID (e.g. <code>pmc_xxx</code>). Used when the override field is empty. Falls back to the Dashboard default if both are empty.' => 'ID Stripe de configuration des moyens de paiement (par ex. <code>pmc_xxx</code>). Utilisé si la surcharge CSV est vide. Si tout est vide, le Dashboard pilote la liste.',
 );

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Be aware that API files are set into the core/vendor folder.
 
 * Copy the module into ```<thelia_root>/local/modules/``` directory and be sure that the name of the module is StripePayment.
 * Install the Stripe PHP library :
-    * add "stripe/stripe-php" to your composer.json file with command : `composer require stripe/stripe-php:"6.*"`
+    * add "stripe/stripe-php" to your composer.json file with command : `composer require stripe/stripe-php:"^20.0"`
     * or download the library from <https://github.com/stripe/stripe-php/releases> and install it in your `core/vendor` directory
 * Activate it in your Thelia administration panel
 
@@ -24,7 +24,7 @@ Be aware that API files are set into the core/vendor folder.
 Add it in your main thelia composer.json file:
 
 ```
-composer require thelia/stripe-payment-module ~2.0.0
+composer require thelia/stripe-payment-module ^4.0
 ```
 
 ### Configuration
@@ -38,6 +38,33 @@ Then activate the Stripe in the module configuration panel.
 Activate the webhooks in stripe dashboard with the url specified in Thelia Back-office Stripe configuration, 
 and add events listed in Thelia Back-office Stripe configuration.
 
-### Logs
+### Payment methods
+
+Since 4.0 the module no longer hard-codes the list of payment methods (`['card']`).
+Three modes are available, evaluated in priority order:
+
+1. **Override (CSV)** — field `Payment method types override (CSV)`.
+   Comma-separated list of Stripe payment method type identifiers (e.g. `card,twint`).
+   Highest priority, replaces the Dashboard configuration.
+2. **Payment Method Configuration** — field `Payment method configuration ID`.
+   Stripe `pmc_xxx` identifier created in the Dashboard
+   (Settings → Payment methods → Configurations).
+   Used when the override field is empty.
+3. **Dashboard default** — both fields empty.
+   Stripe selects payment methods according to the Dashboard configuration,
+   currency, country and customer eligibility. Recommended for most setups.
+
+#### Migrating from 3.x to 4.0
+
+The pre-4.0 behavior was equivalent to mode 1 with `card`. To preserve that
+behavior when upgrading, the module sets `payment_method_types_override = "card"`
+during the update hook if both new fields are empty.
+
+To switch to the modern Dashboard-driven flow, simply clear the override field
+in the back-office configuration. To use a Payment Method Configuration created
+in the Dashboard, paste its `pmc_xxx` id in the dedicated field (and leave
+the override empty).
+
+### Logs
 
 Stripe error logs are stored in a specific file located in the log folder.

--- a/StripePayment.php
+++ b/StripePayment.php
@@ -79,6 +79,21 @@ class StripePayment extends AbstractPaymentModule
         $this->createMailMessage();
     }
 
+    public function update($currentVersion, $newVersion, ConnectionInterface $con = null): void
+    {
+        // Upgrades from <4.0 hard-coded payment_method_types=['card']. Preserve
+        // that behavior: only seed the override if the merchant has not chosen
+        // a Dashboard-driven setup (PMC id) and the override field is empty.
+        if (version_compare($currentVersion, '4.0.0', '<')) {
+            $existingOverride = (string) (self::getConfigValue(self::STRIPE_PMC_TYPES_OVERRIDE) ?? '');
+            $existingPmcId = (string) (self::getConfigValue(self::CONFIG_PMC_ID) ?? '');
+
+            if ($existingOverride === '' && $existingPmcId === '') {
+                self::setConfigValue(self::STRIPE_PMC_TYPES_OVERRIDE, 'card');
+            }
+        }
+    }
+
     public function createMailMessage()
     {
         // Create payment confirmation message from templates, if not already defined

--- a/StripePayment.php
+++ b/StripePayment.php
@@ -302,6 +302,39 @@ class StripePayment extends AbstractPaymentModule
         return new Response();
     }
 
+    /**
+     * Resolve the payment-method selection for a Stripe Checkout Session.
+     *
+     * Priority: explicit CSV override > Payment Method Configuration id > Dashboard default.
+     * When both fields are empty, no payment_method_types nor payment_method_configuration
+     * key is added so Stripe falls back to the Dashboard configuration.
+     */
+    private function applyPaymentMethodSelection(array $payload): array
+    {
+        $override = trim((string) (StripePayment::getConfigValue(StripePayment::STRIPE_PMC_TYPES_OVERRIDE) ?? ''));
+
+        if ($override !== '') {
+            $types = array_values(array_filter(
+                array_map('trim', explode(',', $override)),
+                static fn (string $type): bool => $type !== ''
+            ));
+
+            if ($types !== []) {
+                $payload['payment_method_types'] = $types;
+
+                return $payload;
+            }
+        }
+
+        $pmcId = trim((string) (StripePayment::getConfigValue(StripePayment::CONFIG_PMC_ID) ?? ''));
+
+        if ($pmcId !== '') {
+            $payload['payment_method_configuration'] = $pmcId;
+        }
+
+        return $payload;
+    }
+
     private static function formatStripeException(\Stripe\Exception\ApiErrorException $e): string
     {
         return sprintf(
@@ -357,12 +390,13 @@ class StripePayment extends AbstractPaymentModule
         $payload = [
             'customer_email' => $order->getCustomer()->getEmail(),
             'client_reference_id' => $order->getRef(),
-            'payment_method_types' => ['card'],
             'line_items' => $lineItems,
             'mode' => 'payment',
             'success_url' => URL::getInstance()->absoluteUrl('/order/placed/' . $order->getId()),
             'cancel_url' => URL::getInstance()->absoluteUrl('/order/failed/' . $order->getId() . '/error'),
         ];
+
+        $payload = $this->applyPaymentMethodSelection($payload);
 
         (new StripePaymentLog())->logText(
             sprintf(

--- a/StripePayment.php
+++ b/StripePayment.php
@@ -52,6 +52,8 @@ class StripePayment extends AbstractPaymentModule
     const PUBLISHABLE_KEY = "publishable_key";
     const WEBHOOKS_KEY = "webhooks_key";
     const SECURE_URL = "secure_url";
+    const STRIPE_PMC_TYPES_OVERRIDE = "payment_method_types_override";
+    const CONFIG_PMC_ID = "payment_method_configuration_id";
 
     public function preActivation(ConnectionInterface $con = null)
     {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "thelia-module",
   "require": {
     "thelia/installer": "~1.1",
-    "stripe/stripe-php": "^v7.100"
+    "stripe/stripe-php": "^20.0"
   },
   "extra": {
     "installer-name": "StripePayment"

--- a/templates/backOffice/default/stripepayment-configuration.html
+++ b/templates/backOffice/default/stripepayment-configuration.html
@@ -152,6 +152,44 @@
                         </div>
                         {/form_field}
 
+                        {form_field form=$form field="payment_method_types_override"}
+                        <div class="form-group {if $error}has-error{/if}">
+                            <label class="control-label" for="{$label_attr.for}">
+                                {$label}
+                                {if $required}<span class="required">*</span>{/if}
+
+                                {form_error form=$form field="payment_method_types_override"}
+                                <br />
+                                <span class="error">{$message|default:null}</span>
+                                {/form_error}
+                            </label>
+
+                            <input type="text" class="form-control" name="{$name}" id="{$label_attr.for}" value="{$value}" placeholder="{intl l='The configuration value payment_method_types_override' d="stripepayment.bo.default"}" />
+                            {if ! empty($label_attr.help)}
+                                <span class="help-block">{$label_attr.help nofilter}</span>
+                            {/if}
+                        </div>
+                        {/form_field}
+
+                        {form_field form=$form field="payment_method_configuration_id"}
+                        <div class="form-group {if $error}has-error{/if}">
+                            <label class="control-label" for="{$label_attr.for}">
+                                {$label}
+                                {if $required}<span class="required">*</span>{/if}
+
+                                {form_error form=$form field="payment_method_configuration_id"}
+                                <br />
+                                <span class="error">{$message|default:null}</span>
+                                {/form_error}
+                            </label>
+
+                            <input type="text" class="form-control" name="{$name}" id="{$label_attr.for}" value="{$value}" placeholder="{intl l='The configuration value payment_method_configuration_id' d="stripepayment.bo.default"}" />
+                            {if ! empty($label_attr.help)}
+                                <span class="help-block">{$label_attr.help nofilter}</span>
+                            {/if}
+                        </div>
+                        {/form_field}
+
                         <div class="form-group">
                             <label class="control-label" for="web_hooks_urls">{intl l='Webhooks endpoint url' d="stripepayment.bo.default"}</label>
                             <input id="web_hooks_urls" type="text" class="form-control disabled" disabled value="{url path="/module/StripePayment/stripe_webhook/{$value}/listen"}">


### PR DESCRIPTION
## Summary
- Bump `stripe/stripe-php` from `^7.100` to `^20.0`; replace the long-removed
  `\Stripe\Error\SignatureVerification` alias with `SignatureVerificationException`.
- `createStripeSession()` no longer hard-codes `payment_method_types=['card']`.
  Selection is resolved at call time with priority: **CSV override > PMC id > Stripe Dashboard default**.
- Two new back-office fields: `payment_method_types_override` (CSV) and
  `payment_method_configuration_id` (`pmc_xxx`). Both optional.
- `update()` hook seeds `payment_method_types_override="card"` on upgrades
  from <4.0 to preserve legacy behavior. Fresh installs ship empty (Dashboard mode).
- README + CHANGELOG updated. Bumps `module.xml` to `4.0.0`.

## Breaking changes
- Requires `stripe/stripe-php ^20.0` (PHP 7.2+).
- Removed reliance on the `\Stripe\Error\*` aliases (gone since SDK v8).